### PR TITLE
Script for building pxetolive nightly images

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,14 @@ This script will use mock on a Fedora or CentOS machine to build the Fedora Atom
 
 By default it will place the result in `/var/www/html/composes/$(date +%Y-%m-%d)` but that and effectively everything else about the script can be modified using the variables at the top of the script.
 
+## build-pxetolive.sh
+NOTE: this script should be run as sudo and not as root because [mock](https://fedoraproject.org/wiki/Mock?rd=Subprojects/Mock) requires the ability to drop privs
+
+The script will take the installer iso created by `build-iso.sh`, kickstart from the git repository and create live Atomic Host images that can be booted with PXE.
+
+First stage of build is creating raw disk image with livemedia-creator (using virt-install) on build host. This requires lorax, libvirt, virt-install, and qemu-kvm packages installed. Second stage - building live images from raw disk image with livemedia-creator is done in mock. The result should be placed into `/var/www/html/composes/$(date +%Y-%m-%d)` tree in `pxetolive` subdirectory.
+
+More info on PXE to Live Atomic: http://www.projectatomic.io/blog/2015/05/building-and-running-live-atomic/
+
 ## clean-isos.sh
 Simple script to limit the number of historic composes to keep on disk. Defaults to 30, but is configurable. This should be run in root’s cron or in the cron of an user with sudo ALL

--- a/build-pxetolive.sh
+++ b/build-pxetolive.sh
@@ -1,0 +1,139 @@
+fed_ver="22"
+fed_arch="x86_64"
+fed_compose="$(date +%Y%m%d)"
+
+kickstart_name="fedora-atomic-pxe-live.ks"
+kickstart_url="https://github.com/rvykydal/anaconda-kickstarts/raw/master/atomic/${kickstart_name}"
+
+mock_src="fedora-${fed_ver}-${fed_arch}"
+mock_target="fedora-${fed_ver}-pxetolive-${fed_arch}"
+mock_cmd="mock -r ${mock_target}"
+
+build_deps="lorax"
+
+atomic_dest="/atomic-repo"
+atomic_pxetolive_dir="${atomic_dest}/${fed_ver}/Cloud_Atomic/${fed_arch}/pxetolive/"
+
+# FIXME - use real directory
+#http_root_dir="/var/www/html/composes"
+http_root_dir="/root/var/www/html/composes"
+http_compose_dir="${http_root_dir}/$(date +%Y-%m-%d)"
+
+pxetolive_diskimage_log_dir="logs/pxetolive/diskimage"
+pxetolive_liveimage_log_dir="logs/pxetolive/liveimage"
+
+diskimage_name="fedora-atomic-pxetolive-disk.raw"
+mock_diskimage_dir="/diskimage"
+diskimage_dir="/var/tmp"
+
+iso_name="Fedora-Cloud_Atomic-${fed_arch}-${fed_ver}-${fed_compose}.iso"
+
+############## Build raw disk image on host
+# We don't probably want to run virt-install in mock.
+
+#### Copy iso to libvirt
+cmd="cp ${http_compose_dir}/${fed_ver}/Cloud_Atomic/${fed_arch}/iso/${iso_name} /var/lib/libvirt/images"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+# FIXME - update and use https://git.fedorahosted.org/cgit/spin-kickstarts.git/tree/fedora-cloud-atomic-pxetolive.ks
+# This kickstart is for disk image instllation using installer iso
+#### Fetch kickstart
+cmd="wget ${kickstart_url}"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+#### Start libvirtd
+cmd="systemctl start libvirtd.service"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+#### Create raw disk image
+cmd="livemedia-creator --make-disk --image-name=${diskimage_name} --iso=/var/lib/libvirt/images/${iso_name} --ks=${kickstart_name} --ram=1500 --vnc=spice"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+#### Create disk build logs dir
+cmd="mkdir -p ${http_compose_dir}/${pxetolive_diskimage_log_dir}"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+#### Move livemedia-creator logs
+cmd="cp livemedia.log program.log virt-install.log ${http_compose_dir}/${pxetolive_diskimage_log_dir}"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+############## Build live images in mock
+
+if ! [[ -f /etc/mock/${mock_target}.cfg ]]; then
+    cp /etc/mock/${mock_src}.cfg /etc/mock/${mock_target}.cfg
+    printf \
+        "config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/dev', '/dev' ))\n" \
+        >> /etc/mock/${mock_target}.cfg
+    printf \
+        "config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('${diskimage_dir}', '${mock_diskimage_dir}' ))\n" \
+        >> /etc/mock/${mock_target}.cfg
+
+    #FIXME (maybe?) this is a bit of a dirty hammer swing to set the buildroot name
+    sed -i "s/${mock_src}/${mock_target}/g" /etc/mock/${mock_target}.cfg
+
+fi
+
+#### Clean previous environment and setup new one
+${mock_cmd} --clean || exit 1
+${mock_cmd} --init || exit 1
+${mock_cmd} --install ${build_deps} || exit 1
+
+#### Create destination directory
+cmd="mkdir ${atomic_dest}"
+printf "RUNNINING CMD: ${cmd}\n"
+${mock_cmd} --shell "${cmd}" || exit 1
+
+#### Create logdir
+cmd="mkdir -p ${atomic_dest}/${pxetolive_liveimage_log_dir}"
+printf "RUNNINING CMD: ${cmd}\n"
+${mock_cmd} --shell "${cmd}" || exit 1
+
+# FIXME - remove when the package is in stable updates
+#### HACK Use lorax-22.12-1.fc22 with patch for --resultdir
+cmd="cp ${mock_diskimage_dir}/livemedia-creator /usr/sbin/livemedia-creator"
+printf "RUNNINING CMD: ${cmd}\n"
+${mock_cmd} --shell "${cmd}" || exit 1
+
+#### Build Atomic ISO installer
+cmd="livemedia-creator \
+     --make-ostree-live \
+     --disk-image=${mock_diskimage_dir}/${diskimage_name} \
+     --live-rootfs-keep-size \
+     --resultdir=${atomic_pxetolive_dir} " || exit 1
+printf "RUNNINING CMD: ${cmd}\n"
+${mock_cmd} --shell "${cmd}" || exit 1
+
+#### Copy logs
+cmd="cp livemedia.log program.log ${atomic_dest}/${pxetolive_liveimage_log_dir}"
+printf "RUNNINING CMD: ${cmd}\n"
+${mock_cmd} --shell "${cmd}" || exit 1
+
+cmd="mkdir -p ${http_compose_dir}"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+cmd="cp -r /var/lib/mock/${mock_target}/root/${atomic_dest}/* ${http_compose_dir}"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+cmd="chown -R apache:apache ${http_compose_dir}/*"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+# FIXME - do it
+##### Remove kickstart
+#cmd="rm ${kickstart_name}"
+#printf "RUNNINING CMD: ${cmd}\n"
+#${cmd}
+
+# FIXME - do it
+##### Remove raw disk image
+#cmd="rm ${diskimage_dir}/${diskimage_name}"
+#printf "RUNNINING CMD: ${cmd}\n"
+#${cmd}

--- a/build-pxetolive.sh
+++ b/build-pxetolive.sh
@@ -15,9 +15,7 @@ build_deps="lorax"
 atomic_dest="/atomic-repo"
 atomic_pxetolive_dir="${atomic_dest}/${fed_ver}/Cloud_Atomic/${fed_arch}/pxetolive/"
 
-# FIXME - use real directory
-#http_root_dir="/var/www/html/composes"
-http_root_dir="/root/var/www/html/composes"
+http_root_dir="/var/www/html/composes"
 http_compose_dir="${http_root_dir}/$(date +%Y-%m-%d)"
 
 pxetolive_diskimage_log_dir="logs/pxetolive/diskimage"

--- a/build-pxetolive.sh
+++ b/build-pxetolive.sh
@@ -30,7 +30,8 @@ iso_name="Fedora-Cloud_Atomic-${fed_arch}-${fed_ver}-${fed_compose}.iso"
 ############## Build raw disk image on host
 # We don't probably want to run virt-install in mock.
 
-#### Copy iso to libvirt
+#### Copy iso to location accessible by virt
+# FIXME can we set permissions somehow so we don't have to cp the iso?
 cmd="cp ${http_compose_dir}/${fed_ver}/Cloud_Atomic/${fed_arch}/iso/${iso_name} /var/lib/libvirt/images"
 printf "RUNNINING CMD: ${cmd}\n"
 ${cmd}
@@ -52,6 +53,11 @@ ${cmd}
 
 #### Move livemedia-creator logs
 cmd="cp livemedia.log program.log virt-install.log ${http_compose_dir}/${pxetolive_diskimage_log_dir}"
+printf "RUNNINING CMD: ${cmd}\n"
+${cmd}
+
+#### Remove copy of iso image
+cmd="rm /var/lib/libvirt/images/${iso_name}"
 printf "RUNNINING CMD: ${cmd}\n"
 ${cmd}
 

--- a/build-pxetolive.sh
+++ b/build-pxetolive.sh
@@ -115,12 +115,6 @@ printf "RUNNINING CMD: ${cmd}\n"
 ${cmd}
 
 # FIXME - do it
-##### Remove kickstart
-#cmd="rm ${kickstart_name}"
-#printf "RUNNINING CMD: ${cmd}\n"
-#${cmd}
-
-# FIXME - do it
 ##### Remove raw disk image
 #cmd="rm ${diskimage_dir}/${diskimage_name}"
 #printf "RUNNINING CMD: ${cmd}\n"

--- a/build-pxetolive.sh
+++ b/build-pxetolive.sh
@@ -88,12 +88,6 @@ cmd="mkdir -p ${atomic_dest}/${pxetolive_liveimage_log_dir}"
 printf "RUNNINING CMD: ${cmd}\n"
 ${mock_cmd} --shell "${cmd}" || exit 1
 
-# FIXME - remove when the package is in stable updates
-#### HACK Use lorax-22.12-1.fc22 with patch for --resultdir
-cmd="cp ${mock_diskimage_dir}/livemedia-creator /usr/sbin/livemedia-creator"
-printf "RUNNINING CMD: ${cmd}\n"
-${mock_cmd} --shell "${cmd}" || exit 1
-
 #### Build Atomic ISO installer
 cmd="livemedia-creator \
      --make-ostree-live \

--- a/build-pxetolive.sh
+++ b/build-pxetolive.sh
@@ -2,8 +2,9 @@ fed_ver="22"
 fed_arch="x86_64"
 fed_compose="$(date +%Y%m%d)"
 
+# FIXME - update and use https://git.fedorahosted.org/cgit/spin-kickstarts.git/tree/fedora-cloud-atomic-pxetolive.ks
+# This kickstart is for disk image instllation using installer iso
 kickstart_name="fedora-atomic-pxe-live.ks"
-kickstart_url="https://github.com/rvykydal/anaconda-kickstarts/raw/master/atomic/${kickstart_name}"
 
 mock_src="fedora-${fed_ver}-${fed_arch}"
 mock_target="fedora-${fed_ver}-pxetolive-${fed_arch}"
@@ -22,7 +23,7 @@ http_compose_dir="${http_root_dir}/$(date +%Y-%m-%d)"
 pxetolive_diskimage_log_dir="logs/pxetolive/diskimage"
 pxetolive_liveimage_log_dir="logs/pxetolive/liveimage"
 
-diskimage_name="fedora-atomic-pxetolive-disk.raw"
+diskimage_name="fedora-atomic-pxetolive-disk-${fed_compose}.raw"
 mock_diskimage_dir="/diskimage"
 diskimage_dir="/var/tmp"
 
@@ -33,13 +34,6 @@ iso_name="Fedora-Cloud_Atomic-${fed_arch}-${fed_ver}-${fed_compose}.iso"
 
 #### Copy iso to libvirt
 cmd="cp ${http_compose_dir}/${fed_ver}/Cloud_Atomic/${fed_arch}/iso/${iso_name} /var/lib/libvirt/images"
-printf "RUNNINING CMD: ${cmd}\n"
-${cmd}
-
-# FIXME - update and use https://git.fedorahosted.org/cgit/spin-kickstarts.git/tree/fedora-cloud-atomic-pxetolive.ks
-# This kickstart is for disk image instllation using installer iso
-#### Fetch kickstart
-cmd="wget ${kickstart_url}"
 printf "RUNNINING CMD: ${cmd}\n"
 ${cmd}
 

--- a/fedora-atomic-pxe-live.ks
+++ b/fedora-atomic-pxe-live.ks
@@ -1,0 +1,31 @@
+# Settings for unattended installation:
+lang en_US.UTF-8
+keyboard us
+timezone America/New_York
+zerombr
+clearpart --all --initlabel
+rootpw --plaintext atomic
+network --bootproto=dhcp --device=link --activate
+
+# We are only able to install atomic with separate /boot partition currently
+part / --fstype="ext4" --size=6000
+part /boot --size=500 --fstype="ext4"
+
+shutdown
+
+# Including settings created during installer iso compose in
+# interactive-defaults.ks because they are overriden by regular kickstart file
+# like this.  It contains eg ostreesetup command pointing to repo in iso,
+# services enablement, ...
+%include /usr/share/anaconda/interactive-defaults.ks
+
+services --disabled=docker-storage-setup
+services --enabled=cloud-init,cloud-init-local,cloud-final,cloud-config
+
+# We copy content of separate /boot partition to root part when building live squashfs image,
+# and we don't want systemd to try to mount it when pxe booting
+%post
+cat /dev/null > /etc/fstab
+%end
+
+


### PR DESCRIPTION
First stage of build is creating raw disk image from installer iso (we are using iso generated by build-iso.sh) using kickstart from git repo. It is done by livemedia-creator using virt-install on host. This requires lorax, libvirt, virt-install, and qemu-kvm packages on the build host.

Second stage - building live images from raw disk image with livemedia-creator is done in mock which is fine as we want eg selinux policies of the target OS.
